### PR TITLE
Fixed the T2 backpack crafting recipe

### DIFF
--- a/src/mariculture/plugins/PluginForestry.java
+++ b/src/mariculture/plugins/PluginForestry.java
@@ -104,8 +104,8 @@ public class PluginForestry extends Plugin {
 						FluidRegistry.getFluidStack("water", 1000),
 						null,
 						new ItemStack(aquaBackpackT2),
-						new Object[] { "WDW", "WTW", "WWW", Character.valueOf('D'), Item.diamond,
-									Character.valueOf('W'), silk, Character.valueOf('B'), aquaBackpackT1 });
+						new Object[] { "WDW", "WBW", "WWW", Character.valueOf('D'), Item.diamond,
+									Character.valueOf('W'), Item.silk, Character.valueOf('B'), aquaBackpackT1 });
 			}
 
 			FuelManager.bronzeEngineFuel.put(FluidRegistry.getFluid(FluidDictionary.fish_oil), new EngineBronzeFuel(


### PR DESCRIPTION
String mismatch, making sure Item.silk is referenced instead of the
hanging "silk".
