### PR TITLE
loot and enchantment fixes

### DIFF
--- a/src/main/java/mariculture/fishery/FishingHandler.java
+++ b/src/main/java/mariculture/fishery/FishingHandler.java
@@ -237,14 +237,17 @@ public class FishingHandler implements IFishing {
             if (Vanilla.VANILLA_LOOT && type == RodType.DIRE) return getVanillaLoot(world, player, stack, 0, 0);
             if (type != null) {
                 ItemStack loot = null;
-                int lootBonus = EnchantmentHelper.getEnchantmentLevel(Enchantment.field_151370_z.effectId, stack);
-                if (lootBonus > 0 && world.rand.nextInt(200) < lootBonus * 10 || world.rand.nextInt(1000) < Math.max(0.01D, type.getChances().get(0))) {
+                
+                // Vanilla Luck of the Sea increases treasure and decreases junk chance by roughly 2% 
+                // Trying to emulate this here
+                int lootBonus = EnchantmentHelper.getEnchantmentLevel(Enchantment.field_151370_z.effectId, stack) * 2;
+                
+                if (world.rand.nextInt(1000) < Math.max(0, type.getChances().get(2) + lootBonus) * 10) {
                     loot = getLoot(world, type, Rarity.RARE);
                 } else {
-                    double chance = Math.max(0.01D, type.getChances().get(1));
-                    if (lootBonus > 0 && world.rand.nextInt(250) < lootBonus * 10 || world.rand.nextInt(1000) < Math.max(0.01D, type.getChances().get(1))) {
+                    if (world.rand.nextInt(1000) < Math.max(0, type.getChances().get(1) + lootBonus) * 10) {
                         loot = getLoot(world, type, Rarity.GOOD);
-                    } else if (lootBonus > 0 && world.rand.nextInt(300) < lootBonus * 10 || world.rand.nextInt(1000) < Math.max(0.01D, type.getChances().get(2))) {
+                    } else if (world.rand.nextInt(1000) < Math.max(0, type.getChances().get(0) - lootBonus) * 10) {
                         loot = getLoot(world, type, Rarity.JUNK);
                     }
                 }


### PR DESCRIPTION
use vanilla mechanic for "luck of the sea" checks
fixed a bug where the "junk" chance was being used for rare and vice versa
(same thing i did for the 1.3 version a while ago too)