### PR TITLE
Biome-specific top & filler blocks.

### DIFF
--- a/src/main/java/mariculture/core/handlers/WorldEventHandler.java
+++ b/src/main/java/mariculture/core/handlers/WorldEventHandler.java
@@ -75,8 +75,8 @@ public class WorldEventHandler {
 
     public static final void genBiomeTerrain(World world, Random rand, Block[] blocksArray, byte[] metaArray, int x, int z, double noise, BiomeGenBase biome, double depth) {
         Block seabed = WorldGen.LIMESTONE_FLOOR ? Core.limestone : Blocks.sandstone;
-        Block topBlock = Blocks.grass;
-        Block fillerBlock = Blocks.dirt;
+        Block topBlock = biome.topBlock;
+        Block fillerBlock = biome.fillerBlock;
         boolean flag = true;
         Block block = topBlock;
         byte b0 = 0;


### PR DESCRIPTION
Fixes an issue with WorldEventHandler#genBiomeTerrain hardcoding grass and dirt as the top & filler blocks. Instead, it uses the top & filler blocks of the `biome` parameter, resulting in this:

![](http://i.imgur.com/UrC4YRP.gif)